### PR TITLE
Remove Extra Dependencies Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ pip install molecule docker-py
 molecule test
 ```
 
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in
-regards to parameters that may need to be set for other roles, or variables that
-are used from other roles.
 
 License
 -------


### PR DESCRIPTION
Remove the extra section in the README file for role dependencies.